### PR TITLE
Stop execution of action with an error code if Molecule failed previously

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .ansible*
 .cache
 requirements.txt
+.pytest_cache

--- a/action.yml
+++ b/action.yml
@@ -88,4 +88,4 @@ inputs:
 
 runs:
   using: docker
-  image: docker://avdteam/action-molecule:v1.1
+  image: docker://avdteam/action-molecule:dev

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,7 +1,7 @@
 CURRENT_DIR = $(shell pwd)
 DOCKER_NAME ?= action-molecule
 DOCKER_BASE ?= avdteam
-DOCKER_TAG ?= v1.0
+DOCKER_TAG ?= dev
 DOCKER_DIR ?= .
 
 .PHONY: help

--- a/docker/dev.env
+++ b/docker/dev.env
@@ -3,6 +3,6 @@ INPUT_PIP_FILE=requirements.txt
 INPUT_MOLECULE_PARENTDIR=ansible_collections/arista/cvp
 INPUT_MOLECULE_COMMAND=test
 INPUT_MOLECULE_ARGS=--scenario-name cv_configlet
-INPUT_CHECK_GIT=true
+INPUT_CHECK_GIT=false
 INPUT_CHECK_GIT_ENFORCED=false
 INPUT_ANSIBLE=ansible>=2.10

--- a/docker/molecule-runner.sh
+++ b/docker/molecule-runner.sh
@@ -13,8 +13,11 @@ echo "Script running from ${PWD}"
 
 # Install Ansible package
 if [ ${INPUT_ANSIBLE} =~ 'ansible.*' ] 2> /dev/null; then
-    echo 'installing specific ansible version +'${INPUT_ANSIBLE}+' ...'
+    echo 'installing specific ansible version '${INPUT_ANSIBLE}+' ...'
     pip install ${INPUT_ANSIBLE}
+else
+    echo 'installing latest ansible version ...'
+    pip install ansible
 fi
 
 # If user define any requirements file in options, we install them
@@ -41,6 +44,12 @@ fi
 echo "Running: molecule ${INPUT_MOLECULE_OPTIONS} ${INPUT_MOLECULE_COMMAND} ${INPUT_MOLECULE_ARGS}"
 ${MOLECULE_BIN} --version
 ${MOLECULE_BIN} ${INPUT_MOLECULE_OPTIONS} ${INPUT_MOLECULE_COMMAND} ${INPUT_MOLECULE_ARGS}
+export MOLECULE_STATE=$?
+
+if [ ${MOLECULE_STATE} -eq 1 ]; then
+    echo "Molecule failed! Exiting action with error code "${MOLECULE_STATE}
+    exit ${MOLECULE_STATE}
+fi
 
 if [ ${INPUT_CHECK_GIT} = "true" ]; then
     git config core.fileMode false


### PR DESCRIPTION
Example:

```bash
doker run --rm -it \
    -v /Users/Projects/arista-community/action-molecule-avd/docker:/projects \
    -v /var/run/docker.sock:/var/run/docker.sock \
    --env-file dev.env avdteam/action-molecule:dev
Script running from /projects
installing latest ansible version ...
Collecting ansible
[...]
molecule 3.3.2 using python 3.6 
    ansible:2.11.1
    delegated:3.3.2 from molecule
    docker:0.2.4 from molecule_docker
CRITICAL 'molecule/cv_configlet/molecule.yml' glob failed.  Exiting.
Molecule failed! Exiting action with error code 1
make: *** [run] Error 1
```

Image is available on [docker hub for testing](https://hub.docker.com/repository/registry-1.docker.io/avdteam/action-molecule/tags?page=1&ordering=last_updated)
