### PR TITLE
Make(github): Add PR linter for conventional commits

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
       - master
-    tags:
-      - v*
+      - releases/*
 
 jobs:
   changelog:

--- a/.github/workflows/pr_linter.yml
+++ b/.github/workflows/pr_linter.yml
@@ -1,0 +1,61 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - ready_for_review
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      # Please look up the latest version from
+      # https://github.com/amannn/action-semantic-pull-request/releases
+      - uses: amannn/action-semantic-pull-request@v3.4.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure which types are allowed.
+          # Default: https://github.com/commitizen/conventional-commit-types
+          types: |
+            Feat
+            Fix
+            Cut
+            Doc
+            CI
+            Start
+            Stop
+            Bump
+            Test
+            Make
+            Refactor
+            Reformat
+            Optimize
+            License
+            Revert
+          # Configure which scopes are allowed.
+          scopes: |
+            docker
+            entrypoint
+            github
+            requirements
+          # Configure that a scope must always be provided.
+          requireScope: false
+          # Configure additional validation for the subject based on a regex.
+          # This example ensures the subject doesn't start with an uppercase character.
+          # subjectPattern: ^(?![A-Z]).+$
+          # If `subjectPattern` is configured, you can use this property to override
+          # the default error message that is shown when the pattern doesn't match.
+          # The variables `subject` and `title` can be used within the message.
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+          # When using "Squash and merge" on a PR with only one commit, GitHub
+          # will suggest using that commit message instead of the PR title for the
+          # merge commit, and it's easy to commit this by mistake. Enable this option
+          # to also validate the commit message for one commit PRs.
+          validateSingleCommit: true


### PR DESCRIPTION
Enforce Conventionnal Commit syntax

__types:__
- Feat
- Fix
- Cut
- Doc
- CI
- Start
- Stop
- Bump
- Test
- Make
- Refactor
- Reformat
- Optimize
- License
- Revert

__scopes:__
- docker
- entrypoint
- github
- requirements