### PR TITLE
Fix: Fail on all error codes

### DIFF
--- a/docker/molecule-runner.sh
+++ b/docker/molecule-runner.sh
@@ -55,7 +55,7 @@ ${MOLECULE_BIN} --version
 ${MOLECULE_BIN} ${INPUT_MOLECULE_OPTIONS} ${INPUT_MOLECULE_COMMAND} ${INPUT_MOLECULE_ARGS}
 export MOLECULE_STATE=$?
 
-if [ ${MOLECULE_STATE} -eq 1 ]; then
+if [ ${MOLECULE_STATE} -ne 0 ]; then
     echo "Molecule failed! Exiting action with error code "${MOLECULE_STATE}
     exit ${MOLECULE_STATE}
 fi


### PR DESCRIPTION
Fixes issues with action not failing when an error code returned other than 1.

Example Pipeline succeeded when error code return is "2" -> `CRITICAL Ansible return code was 2`
[Failure Example](https://github.com/aristanetworks/ansible-avd/actions/runs/4787736697/jobs/8513435695?pr=2516)

Changed code to fail when error code not equal to 0.