### PR TITLE
Fix: Catch git error and consider /github/workspace as safe

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends build-essential wget git curl rsync && \
     curl -fsSL https://get.docker.com | sh
 RUN pip install --upgrade pip molecule "molecule-plugins[docker]"
+# As this container is intended to be run as a github action, we make
+# /github/workspace safe by default
+# TODO - this could probably be implemented better if required in the future by
+# giving the option to use an input parameter
+RUN git config --global --add safe.directory /github/workspace
 ADD molecule-runner.sh /bin/molecule-runner.sh
 
 WORKDIR /projects

--- a/docker/molecule-runner.sh
+++ b/docker/molecule-runner.sh
@@ -65,7 +65,7 @@ if [ ${INPUT_CHECK_GIT} = "true" ]; then
     echo "  * Run Git Verifier because CHECK_GIT is set to ${INPUT_CHECK_GIT}"
     # if git diff-index --quiet HEAD --; then
     if [ -n "$(git status --porcelain)" ]; then
-        # No changes
+        # Some changes
         echo 'Some changes'
         echo '------------'
         git --no-pager status --short
@@ -79,6 +79,11 @@ if [ ${INPUT_CHECK_GIT} = "true" ]; then
             exit 0
         fi
     else
+        e=$?
+        if [ "${e}" -ne "0" ]; then
+            echo "'git status --porcelain' failed to run - something is wrong"
+            exit $e
+        fi
         # No Changes
         echo '    - No change found after running Molecule'
         exit 0


### PR DESCRIPTION
Two Changes


# 1) Adding `/github/workspace` as a safe repo

## Curent error in AVD pipeline

```
Molecule eos_designs_unit_tests_v4.0 > idempotence
fatal: not in a git directory
  * Run Git Verifier because CHECK_GIT is set to true
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
    - No change found after running Molecule
```

## RCA

[
](https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9)
https://github.com/actions/checkout/issues/760


## Verification

```
docker run -it --entrypoint /bin/bash action-molecule-avd:test                                                                                     
root@617f69473711:/projects#
root@617f69473711:/projects#
root@617f69473711:/projects# ls
root@617f69473711:/projects# cat ~/.github
cat: /root/.github: No such file or directory
root@617f69473711:/projects# cat ~/.gitconfig
[safe]
        directory = /github/workspace
```


# 2) Erroring if any git issue happens again

Right now 1) is a problem but more importantly when 1) fails - the action finishes as if everything is ok which is bad.

The fix to the script is able to catch if an issue occurs

## Verification

local verification of the test

```
pstibbons@guillaumemulocher ansible-avd % sh molecule-runner.sh
Script running from /Users/gmuloc/ansible-avd
fatal: not in a git directory
  * Run Git Verifier because CHECK_GIT is set to
fatal: detected dubious ownership in repository at '/gmuloc/ansible-avd'
To add an exception for this directory, call:

        git config --global --add safe.directory /gmuloc/ansible-avd
'git status --porcelain' failed to run - something is wrong
```